### PR TITLE
Add logic to trim long comments

### DIFF
--- a/sync2jira/intermediary.py
+++ b/sync2jira/intermediary.py
@@ -69,7 +69,7 @@ class Issue(object):
             comments.append({
                 'author': comment['author'],
                 'name': comment['name'],
-                'body': comment['body'],
+                'body': trimCommentBody(comment['body']),
                 'id': comment['id'],
                 'date_created': comment['date_created'],
                 'changed': None
@@ -165,7 +165,7 @@ class PR(object):
             comments.append({
                 'author': comment['author'],
                 'name': comment['name'],
-                'body': comment['body'],
+                'body': trimCommentBody(comment['body']),
                 'id': comment['id'],
                 'date_created': comment['date_created'],
                 'changed': None
@@ -246,3 +246,16 @@ def matcher(content, comments):
                     return match
         else:
             return None
+
+def trimCommentBody(commentBody):
+    """
+    Helper function to trim a comment to ensure it is not over 65000 char
+    Ref: https://github.com/release-engineering/Sync2Jira/issues/123
+    
+    :param String commentBody: Comment content
+    :rtype: String
+    """
+    if len(commentBody) > 65000:
+        return commentBody[:65000]
+    else:
+        return commentBody


### PR DESCRIPTION
Integrates upstream change that was catching for when comments coming from pagure/github were too long, see here: https://github.com/release-engineering/Sync2Jira/pull/124

See conversation/issue here: https://github.com/release-engineering/Sync2Jira/issues/123

